### PR TITLE
Do not require mkmf

### DIFF
--- a/lib/prettier/plugin.rb
+++ b/lib/prettier/plugin.rb
@@ -1,5 +1,3 @@
-require "mkmf"
-
 module Danger
   # Ensure files have been formatted with [Prettier](https://prettier.io/)
   #
@@ -71,7 +69,7 @@ module Danger
     # return [String]
     def prettier_path
       local = executable_path ? executable_path : "./node_modules/.bin/prettier"
-      File.exist?(local) ? local : find_executable("prettier")
+      File.exist?(local) ? local : "prettier"
     end
 
     # Get prettier' file pattern regex


### PR DESCRIPTION
Unfortunately, `mkmf` brings in a lot of baggage when included. In particular,
`mkmf` brings along it's `message` method to the global namespace. Danger likes
to bring in it's baggage too; so they conflict and bad things happen:

```
Danger::DSLError:
[!] Invalid `Dangerfile` file: malformed format string - %(
 #  from Dangerfile:30
 #  -------------------------------------------
 #  def show_coverage
 >    simplecov.report('coverage/coverage.json')
 #  end
 #  -------------------------------------------

  /usr/local/lib/ruby/2.4.0/mkmf.rb:929:in `printf'
  /usr/local/lib/ruby/2.4.0/mkmf.rb:929:in `message'
  /usr/local/bundle/gems/danger-simplecov_json-0.3.0/lib/simplecov_json/plugin.rb:31:in `report'
```

Previously, we used `mkmf` to find an executable path. Luckily, using backticks
will automatically search $PATH for the executable so we can forego `mkmf`
entirely.